### PR TITLE
Remove score penalty in Word Search game

### DIFF
--- a/src/components/ScrambledWordGame.tsx
+++ b/src/components/ScrambledWordGame.tsx
@@ -139,8 +139,8 @@ export const WordSearchGame: React.FC = () => {
         if (timerRef.current) clearInterval(timerRef.current);
         
         const missedWords = gameState.words.filter(w => !w.found);
-        const penalty = missedWords.length * 15;
-        const finalScore = gameState.score - penalty;
+        // The penalty calculation has been removed. The score will no longer be reduced.
+        const finalScore = gameState.score;
 
         setGameState(prev => ({ ...prev, isGameOver: true, isPaused: true, score: finalScore }));
         


### PR DESCRIPTION
This update modifies the scoring logic for the word search game. Previously, at the end of a game, a penalty was calculated based on the number of words the player failed to find, and this penalty was subtracted from their final score.

The change removes this penalty system entirely. Now, the player's final score is based solely on the points accumulated from the words they successfully guessed during the game. The score will no longer decrease at the end for missed words, providing a more encouraging and purely additive scoring experience.